### PR TITLE
Prevent duplicated widget

### DIFF
--- a/lib/src/interactive_scroll_viewer.dart
+++ b/lib/src/interactive_scroll_viewer.dart
@@ -40,8 +40,13 @@ class _InteractiveScrollViewerState extends State<InteractiveScrollViewer> {
       } else {
         _idList.add(scrollContents.id);
       }
-      widget.scrollToId!.scrollContentsList
-          .add(ScrollContentWithKey.fromWithout(scrollContents));
+
+      // Check if scrollContentList already contains this scrollContent to prevent duplicated widgets.
+      if (!widget.scrollToId!.scrollContentsList
+          .any((x) => x.id == scrollContents.id)) {
+        widget.scrollToId!.scrollContentsList
+            .add(ScrollContentWithKey.fromWithout(scrollContents));
+      }
     }
   }
 

--- a/lib/src/interactive_scroll_viewer.dart
+++ b/lib/src/interactive_scroll_viewer.dart
@@ -41,7 +41,7 @@ class _InteractiveScrollViewerState extends State<InteractiveScrollViewer> {
         _idList.add(scrollContents.id);
       }
 
-      // Check if scrollContentList already contains this scrollContent to prevent duplicated widgets.
+      // Check if scrollContentList already contains this scrollContent or not to prevent duplicated widgets.
       if (!widget.scrollToId!.scrollContentsList
           .any((x) => x.id == scrollContents.id)) {
         widget.scrollToId!.scrollContentsList


### PR DESCRIPTION
There is an issue when we refresh our page, the content gets duplicated.
Like for example when we navigate with `GoRouter` from another route back to route where it has `InteractiveScrollViewer` the `ScrollContentList` keep adding the widget all over again. While clearing the scrollContentList helps, it doesn't address the main cause. That's why I created this patch.

```dart
 /// Convert ScrollContent to ScrollContentWithKey
    for (ScrollContent scrollContents in widget.children) {
      ...
      
      widget.scrollToId!.scrollContentsList
          .add(ScrollContentWithKey.fromWithout(scrollContents));
    }
```

into

```dart
/// Convert ScrollContent to ScrollContentWithKey
    for (ScrollContent scrollContents in widget.children) {
      ...
            
      // Check if scrollContentList already contains this scrollContent or not to prevent duplicated widgets.
      if (!widget.scrollToId!.scrollContentsList
          .any((x) => x.id == scrollContents.id)) {
        widget.scrollToId!.scrollContentsList
            .add(ScrollContentWithKey.fromWithout(scrollContents));
      }
    }
```